### PR TITLE
Change $$ to $ at line 493: keep_tmp_word  

### DIFF
--- a/backmap.pl
+++ b/backmap.pl
@@ -490,7 +490,7 @@ if($verbose == 1){
 
 my $keep_tmp_word = "No";
 if($keep_tmp == 1){
-	$$keep_tmp_word = "Yes";
+	$keep_tmp_word = "Yes";
 }
 
 my $run_bamqc_switch_word = "Yes";


### PR DESCRIPTION
Starting the workflow backmap.pl with the option -kt leaded to a crash, because the variable `keep_tmp_word` was mistakenly set by `$$`

Change $$keep_tmp_word to $keep_tmp_word